### PR TITLE
updatePeriodMillis

### DIFF
--- a/app/src/main/res/values/widget.xml
+++ b/app/src/main/res/values/widget.xml
@@ -1,4 +1,6 @@
 <resources>
+    <integer name="widget_update_period_millis">3600000</integer>  <!-- one hour (will wake the device); set 0 to disable (AlarmManager based updates only) -->
+
     <dimen name="widget_margin">8dp</dimen>
     <dimen name="widget_padding_left">2dp</dimen>
     <dimen name="widget_padding_right">4dp</dimen>

--- a/app/src/main/res/xml/widget_naturalhour_3x2.xml
+++ b/app/src/main/res/xml/widget_naturalhour_3x2.xml
@@ -3,7 +3,7 @@
                     xmlns:tools="http://schemas.android.com/tools"
                     tools:ignore="UnusedAttribute"
 
-    android:updatePeriodMillis="0"
+    android:updatePeriodMillis="@integer/widget_update_period_millis"
     android:widgetCategory="home_screen"
     android:previewImage="@mipmap/ic_launcher_round"
 

--- a/app/src/main/res/xml/widget_naturalhour_4x3.xml
+++ b/app/src/main/res/xml/widget_naturalhour_4x3.xml
@@ -3,7 +3,7 @@
                     xmlns:tools="http://schemas.android.com/tools"
                     tools:ignore="UnusedAttribute"
 
-    android:updatePeriodMillis="0"
+    android:updatePeriodMillis="@integer/widget_update_period_millis"
     android:widgetCategory="home_screen"
     android:previewImage="@mipmap/ic_launcher_round"
 

--- a/app/src/main/res/xml/widget_naturalhour_5x3.xml
+++ b/app/src/main/res/xml/widget_naturalhour_5x3.xml
@@ -3,7 +3,7 @@
                     xmlns:tools="http://schemas.android.com/tools"
                     tools:ignore="UnusedAttribute"
 
-    android:updatePeriodMillis="0"
+    android:updatePeriodMillis="@integer/widget_update_period_millis"
     android:widgetCategory="home_screen|keyguard"
     android:previewImage="@mipmap/ic_launcher_round"
 


### PR DESCRIPTION
Request updates to the widget once an hour; the system gets to decide exactly when the update takes place (and will wake the device). 

Widgets will receive an `ACTION_APPWIDGET_UPDATE` which should restore AlarmManager based updates (scheduled once a minute and will not wake the device). This may resolve issues where the widget fails to update reliably on some devices (#15).