### PR TITLE
release 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 ~
 
-### v0.2.1 (2022-12-05)
+### v0.2.1 (2023-01-09)
 * adds support for system dark mode (night mode).
 * fixes bug where Toast messages are unreadable on api33+.
 * fixes bug "the widget does not update" (#15).
 * fixes bug "broken UI - missing first hour - watches" (#14).
 * fixes bug where the hour is sometimes announced incorrectly.
+* fixes bug "unable to set alarm for all hours when using 'sunset (24)' (#21).
 * misc layout tweaks (margins).
 
 ### v0.2.0 (2022-02-22)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ~
 
+### v0.2.1 (2022-12-05)
+* adds support for system dark mode (night mode).
+* fixes bug where Toast messages are unreadable on api33+.
+* fixes bug "the widget does not update" (#15).
+* fixes bug "broken UI - missing first hour - watches" (#14).
+* fixes bug where the hour is sometimes announced incorrectly.
+* misc layout tweaks (margins).
+
 ### v0.2.0 (2022-02-22)
 * adds support for repeating alarms and notifications (#7); requires `Suntimes v0.14.0` or later.
 * adds alarm UI (NaturalHourSelectFragment, NaturalHourAlarmFragment, and AlarmActivity); responds to `suntimes.action.PICK_EVENT`; extends content-provider to implement `suntimes.action.ADDON_EVENT`. 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Natural Hour does not collect, store, or transmit personal user data. It contain
 __Natural Hour is an add-on for Suntimes.__ It uses the `suntimes.permission.READ_CALCULATOR` permission in order to access data provided by this app. https://github.com/forrestguice/SuntimesWidget/wiki/Privacy
 
 ## Legal Stuff
-Copyright (C) 2020-2022 **Forrest Guice**
+Copyright (C) 2020-2023 **Forrest Guice**
 ```
 Natural Hour is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,8 +7,8 @@ android {
         minSdkVersion 14
         //noinspection OldTargetApi
         targetSdkVersion 28
-        versionCode 2
-        versionName "0.2.0"
+        versionCode 3
+        versionName "0.2.1"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""

--- a/fastlane/metadata/android/en-US/changelogs/3.txt
+++ b/fastlane/metadata/android/en-US/changelogs/3.txt
@@ -2,3 +2,4 @@
 - fixes bug "the widget does not update" (#15).
 - fixes bug "broken UI - missing first hour - watches" (#14).
 - fixes bug where the hour is sometimes announced incorrectly.
+- fixes bug "unable to set alarm for all hours when using 'sunset (24)' (#21).

--- a/fastlane/metadata/android/en-US/changelogs/3.txt
+++ b/fastlane/metadata/android/en-US/changelogs/3.txt
@@ -1,0 +1,4 @@
+- adds support for system dark mode (night mode).
+- fixes bug "the widget does not update" (#15).
+- fixes bug "broken UI - missing first hour - watches" (#14).
+- fixes bug where the hour is sometimes announced incorrectly.


### PR DESCRIPTION
* adds support for system dark mode (night mode).
* fixes bug where Toast messages are unreadable on api33+.
* fixes bug "the widget does not update" (closes #15).
* fixes bug "broken UI - missing first hour - watches" (closes #14).
* fixes bug where the hour is sometimes announced incorrectly.
* fixes bug "unable to set alarm for all hours when using 'sunset (24)' (closes #21).
* misc layout tweaks (margins).