### PR TITLE
release 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ~
 
+### v0.2.2 (2023-08-04)
+* adds UTC to time zone settings.
+* adds themed app icon (api33+).
+* adds support for "text size" and "high contrast" app themes.
+* fixes bug "watch face shows broken daylight" (#22).
+* updates SuntimesAddon dependency (v0.3.0 -> v0.4.0).
+
 ### v0.2.1 (2023-01-09)
 * adds support for system dark mode (night mode).
 * fixes bug where Toast messages are unreadable on api33+.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,8 +7,8 @@ android {
         minSdkVersion 14
         //noinspection OldTargetApi
         targetSdkVersion 28
-        versionCode 3
-        versionName "0.2.1"
+        versionCode 4
+        versionName "0.2.2"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""

--- a/fastlane/metadata/android/en-US/changelogs/4.txt
+++ b/fastlane/metadata/android/en-US/changelogs/4.txt
@@ -1,0 +1,4 @@
+- adds UTC to time zone settings.
+- adds themed app icon (api33+).
+- adds support for "text size" and "high contrast" app themes.
+- fixes bug "watch face shows broken daylight" (#22).


### PR DESCRIPTION
* adds UTC to time zone settings.
* adds themed app icon (api33+).
* adds support for "text size" and "high contrast" app themes.
* fixes bug "watch face shows broken daylight" (closes #22).
* updates SuntimesAddon dependency (v0.3.0 -> v0.4.0).