### PR TITLE
release 0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 ~
 
-### v0.2.3 (2024-10-14)
-* fixes bug where "twilight periods are drawn incorrectly in polar regions".
+### v0.2.3 (2024-11-20)
+* fixes bug where "twilight periods are drawn incorrectly" (#30).
+* fixes bug where "alarms times are incorrect when using hours begin at sunset (24)" (#28).
+* fixes ANR when the Suntimes content-provider fails to respond.
 * fixes poor contrast in themed app icon (api33+).
 * updates default color schemes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ~
 
+### v0.2.3 (2024-10-14)
+* fixes bug where "twilight periods are drawn incorrectly in polar regions".
+* fixes poor contrast in themed app icon (api33+).
+* updates default color schemes.
+
 ### v0.2.2 (2023-08-04)
 * adds UTC to time zone settings.
 * adds themed app icon (api33+).

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Natural Hour does not collect, store, or transmit personal user data. It contain
 __Natural Hour is an add-on for Suntimes.__ It uses the `suntimes.permission.READ_CALCULATOR` permission in order to access data provided by this app. https://github.com/forrestguice/SuntimesWidget/wiki/Privacy
 
 ## Legal Stuff
-Copyright (C) 2020-2023 **Forrest Guice**
+Copyright (C) 2020-2024 **Forrest Guice**
 ```
 Natural Hour is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,8 +7,8 @@ android {
         minSdkVersion 14
         //noinspection OldTargetApi
         targetSdkVersion 28
-        versionCode 4
-        versionName "0.2.2"
+        versionCode 5
+        versionName "0.2.3"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -363,7 +363,7 @@
 
     <string name="app_legal1"><![CDATA[
         <b>Source Code:</b><br />
-        Copyright &#169 2020-2023 Forrest Guice <br />
+        Copyright &#169 2020-2024 Forrest Guice <br />
         Source code available under GPLv3.
     ]]></string>
 

--- a/fastlane/metadata/android/en-US/changelogs/5.txt
+++ b/fastlane/metadata/android/en-US/changelogs/5.txt
@@ -1,0 +1,2 @@
+- fixes bug where "twilight periods are drawn incorrectly in polar regions".
+- updates default color schemes.

--- a/fastlane/metadata/android/en-US/changelogs/5.txt
+++ b/fastlane/metadata/android/en-US/changelogs/5.txt
@@ -1,2 +1,3 @@
-- fixes bug where "twilight periods are drawn incorrectly in polar regions".
+- fixes bug where "twilight periods are drawn incorrectly".
+- fixes bug where "alarms times are incorrect when using hours begin at sunset (24)".
 - updates default color schemes.


### PR DESCRIPTION
* fixes bug where "twilight periods are drawn incorrectly" (closes #30).
* fixes bug "incorrect alarm times when using hours begin at sunset (24) (closes #28).
* fixes potential ANR whenever Suntimes ContentProvider fails to respond.
* fixes poor contrast in themed app icon (api33+).
* updates default color schemes.