### PR TITLE
release 0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ~
 
+### v0.3.3 (2026-04-27)
+* adds "Material You" app themes (api31+).
+* adds widget reconfiguration (api28+) (drag widgets to reconfigure).
+* adds exception handler and crash report notification; adds `android.permission.POST_NOTIFICATION` [permission].
+* adds full backup rules for Android 12+.
+* fixes bug where the wrong help mirror url is shown depending on locale.
+* refactor; replaces deprecated api (PreferenceManager, FragmentViewContainer).
+* build: adds nightly build flavor.
+* updates translation to French (#43 by chfo-bidouille)
+
 ### v0.3.2 (2025-06-03)
 * fixes broken widgets on Android 12+ (#38).
 * adds fullscreen behavior; the floating action button is shown for a moment and then hides itself.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 ### v0.3.3 (2026-04-27)
 * adds "Material You" app themes (api31+).
-* adds widget reconfiguration (api28+) (drag widgets to reconfigure).
+* adds support for `show coordinates` option (requires Suntimes v0.17.0+).
 * adds exception handler and crash report notification; adds `android.permission.POST_NOTIFICATION` [permission].
 * adds full backup rules for Android 12+.
-* fixes bug where the wrong help mirror url is shown depending on locale.
-* refactor; replaces deprecated api (PreferenceManager, FragmentViewContainer).
-* build: adds nightly build flavor.
+* fixes widget reconfiguration (api28+) (drag widgets to reconfigure).
+* fixes bug where help mirror url is incorrect (locale specific).
+* refactors deprecated api (Preference, PreferenceFragment, PreferenceManager, FragmentContainer).
+* updates build: adds nightly build flavor.
 * updates translation to French (#43 by chfo-bidouille)
 
 ### v0.3.2 (2025-06-03)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ~
 
-### v0.3.3 (2026-04-27)
+### v0.3.3 (2026-06-29)
 * adds "Material You" app themes (api31+).
 * adds support for `show coordinates` option (requires Suntimes v0.17.0+).
 * adds exception handler and crash report notification; adds `android.permission.POST_NOTIFICATION` [permission].

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * fixes widget reconfiguration (api28+) (drag widgets to reconfigure).
 * fixes bug where help mirror url is incorrect (locale specific).
 * refactors deprecated api (Preference, PreferenceFragment, PreferenceManager, FragmentContainer).
-* updates build: adds nightly build flavor.
+* updates build: updates SuntimesAddon dependency 0.4.2 -> 0.5.0; adds nightly build flavor.
 * updates translation to French (#43 by chfo-bidouille)
 
 ### v0.3.2 (2025-06-03)

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ Options for:
 ## Donations ##
 Do you find value in this software? Please pay as you feel.
 
-[![paypal](https://www.paypalobjects.com/webstatic/en_US/i/btn/png/silver-rect-paypal-26px.png)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=NZJ5FJBCKY6K2)
-
 <noscript><a href="https://liberapay.com/forrestguice/donate"><img alt="Donate using Liberapay" src="https://liberapay.com/assets/widgets/donate.svg"></a></noscript>
+
+[![paypal](https://www.paypalobjects.com/webstatic/en_US/i/btn/png/silver-rect-paypal-26px.png)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=NZJ5FJBCKY6K2)
 
 
 ## Bug Reports ##
@@ -49,7 +49,7 @@ Natural Hour does not collect, store, or transmit personal user data. It contain
 __Natural Hour is an add-on for Suntimes.__ It uses the `suntimes.permission.READ_CALCULATOR` permission in order to access data provided by this app. https://github.com/forrestguice/SuntimesWidget/wiki/Privacy
 
 ## Legal Stuff
-Copyright (C) 2020-2025 **Forrest Guice**
+Copyright (C) 2020-2026 **Forrest Guice**
 ```
 Natural Hour is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,8 +8,8 @@ android {
         targetSdkVersion 33
         compileSdk 33
 
-        versionCode 8
-        versionName "0.3.2"
+        versionCode 9
+        versionName "0.3.3"
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         vectorDrawables.useSupportLibrary = true

--- a/fastlane/metadata/android/en-US/changelogs/9.txt
+++ b/fastlane/metadata/android/en-US/changelogs/9.txt
@@ -1,4 +1,5 @@
 - adds "Material You" app themes.
-- adds widget reconfiguration (drag widgets to reconfigure).
+- adds support for `show coordinates` option.
 - adds exception handler and crash report notification.
+- fixes widget reconfiguration (drag widgets to reconfigure).
 - updates translation to French.

--- a/fastlane/metadata/android/en-US/changelogs/9.txt
+++ b/fastlane/metadata/android/en-US/changelogs/9.txt
@@ -1,0 +1,4 @@
+- adds "Material You" app themes.
+- adds widget reconfiguration (drag widgets to reconfigure).
+- adds exception handler and crash report notification.
+- updates translation to French.


### PR DESCRIPTION
* adds "Material You" app themes (api31+).
* adds support for `show coordinates` option (requires Suntimes v0.17.0+).
* adds exception handler and crash report notification; adds `android.permission.POST_NOTIFICATION` [permission].
* adds full backup rules for Android 12+.
* fixes widget reconfiguration (api28+) (drag widgets to reconfigure).
* fixes bug where help mirror url is incorrect (locale specific).
* refactors deprecated api (Preference, PreferenceFragment, PreferenceManager, FragmentContainer).
* updates build: adds nightly build flavor.
* updates translation to French (#43 by chfo-bidouille)